### PR TITLE
[SimpleITK] Use SimpleITK to generate NifTI files with correct pixel spacing

### DIFF
--- a/bunkerhill/examples/hippocampus/test_model.py
+++ b/bunkerhill/examples/hippocampus/test_model.py
@@ -1,6 +1,5 @@
 """Test for model.py"""
 
-import os
 import pickle
 import uuid
 
@@ -23,7 +22,17 @@ def test_run_inference(tmp_path: Path, grpc_server: Server):
   study_identifier = str(uuid.uuid4())
   pixel_array = np.random.randint(2, 165, (39, 47, 36), dtype=np.uint8)
   series_uid = '1.2.314159.117779'
-  model_arguments = {'pixel_array': {series_uid: pixel_array}}
+
+  model_arguments = {
+    'image_position_patient': {
+      series_uid: {
+        i + 1: (0., 0., float(i))
+        for i in range(36)
+      }
+    },
+    'pixel_array': {series_uid: pixel_array},
+    'pixel_spacing': {series_uid: (1.0, 1.0)},
+  }
   model_arguments_filename = shared_file_utils.get_model_arguments_filename(
     data_dirname, study_identifier)
   with open(model_arguments_filename, 'wb') as f:
@@ -52,5 +61,5 @@ def test_run_inference(tmp_path: Path, grpc_server: Server):
   assert segmentation.dtype == np.uint8
 
   softmax = outputs[MSDHippocampusModel._SOFTMAX_OUTPUT_ATTRIBUTE_NAME][series_uid]
-  assert softmax.shape == (3, 36, 47, 39)
+  assert softmax.shape == (3, 39, 47, 36)
   assert softmax.dtype == np.float16

--- a/bunkerhill/image_utils.py
+++ b/bunkerhill/image_utils.py
@@ -1,0 +1,30 @@
+"""Utility methods for image processing."""
+
+import logging
+
+
+from typing import Dict, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+def compute_z_dim_pixel_spacing(
+    image_position_patient: Dict[int, Tuple[float, float, float]]
+) -> float:
+  """Computes the z dimension pixel spacing value from the Image Position (Patient) DICOM tag."""
+  instance_indices = image_position_patient.keys()
+  first_instance_index = min(instance_indices)
+  last_instance_index = max(instance_indices)
+  first_z_position = image_position_patient[first_instance_index][2]
+  last_z_position = image_position_patient[last_instance_index][2]
+
+  # Warn if there are missing instances.
+  num_expected_instances = last_instance_index - first_instance_index + 1
+  num_actual_instances = len(instance_indices)
+  if num_actual_instances != num_expected_instances:
+    logger.warning(
+      'Expected %s instances, but received %s instead.',
+      num_expected_instances,
+      num_actual_instances
+    )
+  return abs(last_z_position - first_z_position) / (last_instance_index - first_instance_index)

--- a/bunkerhill/utils/nifti_to_modelrunner_input.py
+++ b/bunkerhill/utils/nifti_to_modelrunner_input.py
@@ -11,13 +11,13 @@ Example usage:
 import argparse
 import pickle
 
-import nibabel as nib
+import SimpleITK as sitk
 
 from bunkerhill import shared_file_utils
 
 
 def main(args: argparse.Namespace) -> None:
-  input_array = nib.load(args.nifti_filename).get_data()
+  input_array = sitk.GetArrayFromImage(sitk.ReadImage(args.nifti_filename))
   pixel_array = {'pixel_array': {args.series_uuid: input_array}}
 
   input_filename = shared_file_utils.get_model_arguments_filename(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="bunkerhill",
-  version="0.0.1",
+  version="0.0.2",
   author="Bunkerhill Health",
   description="SDK for integration with Bunkerhill Health",
   long_description=long_description,
@@ -21,8 +21,8 @@ setuptools.setup(
     'grpcio==1.51.1',
     'grpcio-testing==1.51.1',
     'grpcio-tools==1.51.1',
-    'nibabel==5.0.0',
     'numpy>=1.24.0',
+    'SimpleITK>=2.2.1',
   ],
 )
 


### PR DESCRIPTION
- Uses the SimpleITK library and the DICOM data elements `ImagePositionPatient` and `PixelSpacing` to convert a raw pixel array into a NifTI file with the correct spacing
- Updates the package version to 0.0.2